### PR TITLE
Updated the prereq reporter, made room for version numbers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Set default behavior, in case users don't have core.autocrlf set.
+* text=lf
+
+# Explicitly declare text files we want to always be normalized and converted
+# to native line endings on checkout.
+*.c text eol=lf
+*.h text eol=lf
+*.pl text eol=lf
+*.pm text eol=lf
+*.php text eol=lf
+*.t text eol=lf
+*.html text eol=lf
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sln text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+MooseX-Attribute-Deflator-*.tar.gz
+MooseX-Attribute-Deflator-*/
+Build
+META.yml
+MYMETA.json
+MYMETA.yml
+_build/
+blib/
+cover_db/
+.build/

--- a/dist.ini
+++ b/dist.ini
@@ -29,7 +29,7 @@ Devel::PartialDump = 0
 [Test::MinimumVersion]
 [PodCoverageTests]
 [PodSyntaxTests]
-[ReportVersions::Tiny]
+[Test::ReportPrereqs]
  
 ; -- remove some files
 [PruneCruft]
@@ -37,14 +37,14 @@ Devel::PartialDump = 0
 match = ~$
 [ManifestSkip]
 
- 
+
 ; -- munge files
 [ExtraTests]
 [NextRelease]
 [PkgVersion]
 [PodWeaver]
 [Prepender]
- 
+
 ; -- dynamic meta-information
 [ExecDir]
 [ShareDir]
@@ -53,7 +53,7 @@ web = https://github.com/monken/p5-moosex-attribute-deflator/issues
 [Repository]
 [MetaProvides::Package]
 [MetaConfig]
- 
+
 ; -- generate meta files
 [License]
 [ModuleBuild]
@@ -61,6 +61,6 @@ web = https://github.com/monken/p5-moosex-attribute-deflator/issues
 [MetaJSON]
 [Readme]
 [Manifest] ; should come last
- 
+
 ; -- release
 [CheckChangeLog]

--- a/lib/MooseX/Attribute/LazyInflator/Meta/Role/ApplicationToClass.pm
+++ b/lib/MooseX/Attribute/LazyInflator/Meta/Role/ApplicationToClass.pm
@@ -1,4 +1,5 @@
 package MooseX::Attribute::LazyInflator::Meta::Role::ApplicationToClass;
+
 use Moose::Role;
 use MooseX::Attribute::LazyInflator::Role::Class;
 

--- a/lib/MooseX/Attribute/LazyInflator/Meta/Role/ApplicationToRole.pm
+++ b/lib/MooseX/Attribute/LazyInflator/Meta/Role/ApplicationToRole.pm
@@ -1,4 +1,5 @@
 package MooseX::Attribute::LazyInflator::Meta::Role::ApplicationToRole;
+
 use Moose::Role;
 
 around apply => sub {

--- a/lib/MooseX/Attribute/LazyInflator/Meta/Role/Composite.pm
+++ b/lib/MooseX/Attribute/LazyInflator/Meta/Role/Composite.pm
@@ -1,4 +1,5 @@
 package MooseX::Attribute::LazyInflator::Meta::Role::Composite;
+
 use Moose::Role;
 
 around apply_params => sub {

--- a/lib/MooseX/Attribute/LazyInflator/Meta/Role/Role.pm
+++ b/lib/MooseX/Attribute/LazyInflator/Meta/Role/Role.pm
@@ -1,4 +1,5 @@
 package MooseX::Attribute::LazyInflator::Meta::Role::Role;
+
 use Moose::Role;
 
 sub composition_class_roles {


### PR DESCRIPTION
As part of the [CPAN PR Challenge](http://cpan-prc.org/) I was assigned your module for this month.

When I was looking for something to contribute, I noticed that there were a few warnings that Dist::Zilla was spitting out that I figured I could fairly easily fix.  This PR makes room for the version numbers to be injected in a few places, replaces a deprecated Test plugin, and makes sure git doesn't try to track the DZil build files by adding the `.gitignore` and `.gitattributes` files.

-- Chase
